### PR TITLE
Highlight view

### DIFF
--- a/app/src/main/java/it/sephiroth/android/library/mymodule/app/MainActivity2.java
+++ b/app/src/main/java/it/sephiroth/android/library/mymodule/app/MainActivity2.java
@@ -79,7 +79,7 @@ public class MainActivity2 extends ActionBarActivity implements View.OnClickList
 			manager.create(0)
 			       .anchor(mButton1, TooltipManager.Gravity.RIGHT)
 			       .actionBarSize(Utils.getActionBarSize(getBaseContext()))
-			       .closePolicy(TooltipManager.ClosePolicy.TouchInside, 3000)
+			       .closePolicy(TooltipManager.ClosePolicy.TouchOutside, 3000)
 			       .text(R.string.hello_world)
 			       .toggleArrow(true)
 			       .maxWidth(400)
@@ -90,14 +90,15 @@ public class MainActivity2 extends ActionBarActivity implements View.OnClickList
 			manager.create(1)
 			       .anchor(mButton2, TooltipManager.Gravity.LEFT)
 			       .actionBarSize(Utils.getActionBarSize(getBaseContext()))
-			       .closePolicy(TooltipManager.ClosePolicy.TouchOutside, 0)
-			       .text("Touch outside with background")
+			       .closePolicy(TooltipManager.ClosePolicy.TouchInside, 0)
+			       .text("Touch inside with background and highlighted view")
 			       .toggleArrow(true)
                    .animationDuration(250)
                    .withCustomAnimations(R.animator.pop_in, R.animator.pop_out)
 			       .maxWidth(400)
 			       .withCallback(this)
                    .background(R.color.black_dark_transparent)
+                   .highlightView(mButton2)
 			       .show();
 		}
 		else if (id == mButton3.getId()) {
@@ -105,14 +106,14 @@ public class MainActivity2 extends ActionBarActivity implements View.OnClickList
 			       .anchor(mButton3, TooltipManager.Gravity.TOP)
 			       .actionBarSize(Utils.getActionBarSize(getBaseContext()))
 			       .closePolicy(TooltipManager.ClosePolicy.TouchOutsideExclusive, 0)
-			       .text("Touch outside exclusive with background and bright view")
+			       .text("Touch outside exclusive with background and highlighted view")
 			       .toggleArrow(true)
 			       .maxWidth(400)
 			       .withCallback(this)
                    .animationDuration(200)
                    .withCustomAnimations(R.animator.pop_in, R.animator.pop_out)
 			       .background(R.color.black_dark_transparent)
-                   .brightView(mButton3)
+                   .highlightView(mButton3, R.drawable.highlight)
 			       .show();
 		} else if (id == mButton4.getId()) {
             manager.create(3)
@@ -120,10 +121,11 @@ public class MainActivity2 extends ActionBarActivity implements View.OnClickList
                 .actionBarSize(Utils.getActionBarSize(getBaseContext()))
                 .closePolicy(TooltipManager.ClosePolicy.TouchInsideExclusive, 0)
                 .withCustomView(R.layout.custom_textview, false)
-                .text("Custom view with touch inside exclusive")
+                .text("Custom view with touch inside exclusive and background")
                 .toggleArrow(false)
                 .maxWidth(300)
                 .withCallback(this)
+                .background(R.color.black_dark_transparent)
                 .show();
         } else if (id == mButton5.getId()) {
             manager.create(4)

--- a/app/src/main/res/drawable/highlight.xml
+++ b/app/src/main/res/drawable/highlight.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#550300FF"/>
+    <stroke android:color="#FF0000"
+            android:width="3dp"/>
+
+</shape>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -23,6 +23,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:support-annotations:22.1.1'
 }
 
 

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipBackgroundDrawable.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipBackgroundDrawable.java
@@ -1,38 +1,56 @@
 package it.sephiroth.android.library.tooltip;
 
+import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Color;
+import android.graphics.ColorFilter;
 import android.graphics.Rect;
 import android.graphics.Region;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.TransitionDrawable;
 import android.view.View;
 
-public class TooltipBackgroundDrawable extends TransitionDrawable {
+public class TooltipBackgroundDrawable extends Drawable {
 
-    public TooltipBackgroundDrawable(int color, View brightView) {
-        super(new Drawable[] { new ClippedColorDrawable(Color.TRANSPARENT, brightView),
-                               new ClippedColorDrawable(color, brightView) });
+    private int mBackgroundColor;
+
+    private View mHighlightedView;
+
+    private Drawable mHighlightDrawable;
+
+    public TooltipBackgroundDrawable(Context context, TooltipManager.Builder builder) {
+        mBackgroundColor = context.getResources().getColor(builder.backgroundColorResId);
+        mHighlightedView = builder.highlightView;
+        if (builder.highlightDrawableResId > 0) {
+            mHighlightDrawable = context.getResources().getDrawable(builder.highlightDrawableResId);
+        }
     }
 
-    private static class ClippedColorDrawable extends ColorDrawable {
+    @Override
+    public void draw(Canvas canvas) {
+        if (mHighlightedView != null) {
+            Rect highlightRect = new Rect();
+            mHighlightedView.getGlobalVisibleRect(highlightRect);
 
-        private View mClipView;
-
-        public ClippedColorDrawable(int color, View clipView) {
-            super(color);
-            mClipView = clipView;
-        }
-
-        @Override
-        public void draw(Canvas canvas) {
-            super.draw(canvas);
-            if (mClipView != null) {
-                Rect clipRect = new Rect();
-                mClipView.getGlobalVisibleRect(clipRect);
-                canvas.clipRect(clipRect, Region.Op.DIFFERENCE);
+            if (mHighlightDrawable != null) {
+                mHighlightDrawable.setBounds(highlightRect);
+                mHighlightDrawable.draw(canvas);
             }
+
+            canvas.clipRect(highlightRect, Region.Op.DIFFERENCE);
         }
+
+        canvas.drawColor(mBackgroundColor);
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+    }
+
+    @Override
+    public void setColorFilter(ColorFilter cf) {
+    }
+
+    @Override
+    public int getOpacity() {
+        return 0;
     }
 }

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipManager.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipManager.java
@@ -3,6 +3,13 @@ package it.sephiroth.android.library.tooltip;
 import android.app.Activity;
 import android.content.res.Resources;
 import android.graphics.Point;
+import android.support.annotation.AnimatorRes;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DimenRes;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.StringRes;
+import android.support.annotation.StyleRes;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
@@ -261,23 +268,23 @@ public class TooltipManager {
          * @param replace_background if true the custom view's background won't be replaced
          * @return
          */
-        public Builder withCustomView(int resId, boolean replace_background) {
+        public Builder withCustomView(@LayoutRes int resId, boolean replace_background) {
             this.textResId = resId;
             this.isCustomView = replace_background;
             return this;
         }
 
-        public Builder withCustomView(int resId) {
+        public Builder withCustomView(@LayoutRes int resId) {
             return withCustomView(resId, true);
         }
 
-        public Builder withCustomAnimations(int in, int out) {
+        public Builder withCustomAnimations(@AnimatorRes int in, @AnimatorRes int out) {
             this.inAnimation = in;
             this.outAnimation = out;
             return this;
         }
 
-        public Builder withStyleId(int styleId) {
+        public Builder withStyleId(@StyleRes int styleId) {
             this.defStyleAttr = 0;
             this.defStyleRes = styleId;
             return this;
@@ -298,11 +305,11 @@ public class TooltipManager {
             return this;
         }
 
-        public Builder text(Resources res, int resid) {
+        public Builder text(Resources res, @StringRes int resid) {
             return text(res.getString(resid));
         }
 
-        public Builder text(int resid) {
+        public Builder text(@StringRes int resid) {
             TooltipManager tipManager = manager.get();
             if (null != tipManager) {
                 if (null != tipManager.mActivity) {
@@ -350,7 +357,7 @@ public class TooltipManager {
             return this;
         }
 
-        public Builder actionBarSize(Resources resources, int resId) {
+        public Builder actionBarSize(Resources resources, @DimenRes int resId) {
             return actionBarSize(resources.getDimensionPixelSize(resId));
         }
 
@@ -370,7 +377,7 @@ public class TooltipManager {
             return this;
         }
 
-        public Builder background(int colorResId) {
+        public Builder background(@ColorRes int colorResId) {
             this.backgroundColorResId = colorResId;
             return this;
         }
@@ -384,7 +391,7 @@ public class TooltipManager {
          * @param highlightDrawableResId
          * @return
          */
-        public Builder highlightView(View highlightView, int highlightDrawableResId) {
+        public Builder highlightView(View highlightView, @DrawableRes int highlightDrawableResId) {
             this.highlightView = highlightView;
             this.highlightDrawableResId = highlightDrawableResId;
             return this;

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipManager.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipManager.java
@@ -225,7 +225,7 @@ public class TooltipManager {
         View view;
         Gravity gravity;
         int actionbarSize = 0;
-        int backgroundColorResId = 0;
+        int backgroundColorResId = android.R.color.transparent;
         int textResId = R.layout.tooltip_textview;
         ClosePolicy closePolicy;
         long showDuration;
@@ -243,8 +243,9 @@ public class TooltipManager {
         onTooltipClosingCallback closeCallback;
         int inAnimation = android.R.animator.fade_in;
         int outAnimation = android.R.animator.fade_out;
-        View brightView;
+        View highlightView;
         boolean centerHorizontally = false;
+        int highlightDrawableResId = 0;
 
         Builder(final TooltipManager manager, int id) {
             this.manager = new WeakReference<TooltipManager>(manager);
@@ -375,15 +376,28 @@ public class TooltipManager {
         }
 
         /**
-         * Exclude a view when drawing the background color. Use it create a highlighted view on colored (e.g. dimmed)
-         * background.
+         * Highlight a specific view.
+         * The highlighted view will be excluded when drawing the background, instead a custom
+         * drawable can be drawn on top of it to further highlight it.
          *
-         * @param brightView
+         * @param highlightView
+         * @param highlightDrawableResId
          * @return
          */
-        public Builder brightView(View brightView) {
-            this.brightView = brightView;
+        public Builder highlightView(View highlightView, int highlightDrawableResId) {
+            this.highlightView = highlightView;
+            this.highlightDrawableResId = highlightDrawableResId;
             return this;
+        }
+
+        /**
+         * Like {@link #highlightView(android.view.View, int)}, but no highlighting drawable set.
+         *
+         * @param highlightView
+         * @return
+         */
+        public Builder highlightView(View highlightView) {
+            return highlightView(highlightView, 0);
         }
 
         /**

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipView.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipView.java
@@ -8,6 +8,8 @@ import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Rect;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.text.Html;
 import android.util.Log;
@@ -88,12 +90,10 @@ class TooltipView extends ViewGroup implements Tooltip {
         this.backgroundColorResId = builder.backgroundColorResId;
         this.centerHorizontally = builder.centerHorizontally;
 
-        if (builder.backgroundColorResId > 0) {
-            mBackgroundTransitionDrawable =
-                    new TooltipBackgroundDrawable(getContext().getResources().getColor(backgroundColorResId),
-                                                  builder.brightView);
-            setBackgroundDrawable(mBackgroundTransitionDrawable);
-        }
+        mBackgroundTransitionDrawable = new TransitionDrawable(new Drawable[] {
+                new ColorDrawable(Color.TRANSPARENT),
+                new TooltipBackgroundDrawable(context, builder)});
+        setBackgroundDrawable(mBackgroundTransitionDrawable);
 
         if (null != builder.point) {
             this.point = new Point(builder.point);


### PR DESCRIPTION
Add the possibility to highlight a specific view by means of drawing a custom highlight drawable on top of it.

As this is more or less an enhancement of the current bright view feature, `brightView()` was extended and renamed to `highlightView()`. The plane bright view effect can still be achieved by calling `highlightView()` without passing a custom drawable.